### PR TITLE
flake.nix: Use the module file directly instead of importing it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     lib = import ./lib.nix; # need to pass nixpkgs-lib
     nixosModules = {
       default = inputs.self.nixosModules.preservation;
-      preservation = import ./module.nix;
+      preservation = ./module.nix;
     };
   };
 }


### PR DESCRIPTION
The module system can import the file automatically. Plus, it helps with error messages pointing to the right file.