### PR TITLE
feat: add a 'copy' synchronization method

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -4,6 +4,8 @@ let
   cfg = config.preservation;
 
   inherit (import ./lib.nix { inherit lib; })
+    mkRegularCopyServices
+    mkInitrdCopyServices
     mkRegularMountUnits
     mkInitrdMountUnits
     mkRegularTmpfilesRules
@@ -33,6 +35,9 @@ in
         lib.flatten (lib.mapAttrsToList mkInitrdTmpfilesRules cfg.preserveAt)
       );
       mounts = lib.flatten (lib.mapAttrsToList mkInitrdMountUnits cfg.preserveAt);
+      services = lib.listToAttrs (
+        lib.flatten (lib.mapAttrsToList mkInitrdCopyServices cfg.preserveAt)
+      );
     };
 
     systemd = {
@@ -45,6 +50,9 @@ in
         lib.flatten (lib.mapAttrsToList mkRegularTmpfilesRules cfg.preserveAt)
       );
       mounts = lib.flatten (lib.mapAttrsToList mkRegularMountUnits cfg.preserveAt);
+      services = lib.listToAttrs (
+        lib.flatten (lib.mapAttrsToList mkRegularCopyServices cfg.preserveAt)
+      );
     };
 
   };

--- a/options.nix
+++ b/options.nix
@@ -33,6 +33,7 @@ let
         how = lib.mkOption {
           type = lib.types.enum [
             "bindmount"
+            "copy"
             "symlink"
           ];
           default = "bindmount";
@@ -45,6 +46,11 @@ let
 
             2. Or a symlink is created on the volatile volume, pointing
             to the corresponding location on the persistent volume.
+
+            3. Or the directory is copied onto the volatile volume on
+            startup and copied from the volatile onto the persistent
+            volume on shutdown. Note that this method fails to persist
+            the file when the system crashes.
           '';
         };
         user = lib.mkOption {
@@ -132,6 +138,14 @@ let
             and permissions as target of the symlink.
           '';
         };
+        copyBack = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether to copy the directory back to the persistent storage at
+            shutdown.
+          '';
+        };
         inInitrd = lib.mkOption {
           type = lib.types.bool;
           default = false;
@@ -171,6 +185,7 @@ let
         how = lib.mkOption {
           type = lib.types.enum [
             "bindmount"
+            "copy"
             "symlink"
           ];
           default = "bindmount";
@@ -183,6 +198,11 @@ let
 
             2. Or a symlink is created on the volatile volume, pointing
             to the corresponding location on the persistent volume.
+
+            3. Or the file is copied onto the volatile volume on startup
+            and copied from the volatile onto the persistent volume on
+            shutdown. Note that this method fails to persist the file
+            when the system crashes.
           '';
         };
         user = lib.mkOption {
@@ -267,6 +287,13 @@ let
 
             Specify whether to create an empty file with the specified ownership
             and permissions as target of the symlink.
+          '';
+        };
+        copyBack = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether to copy the file back to the persistent storage at shutdown.
           '';
         };
         inInitrd = lib.mkOption {
@@ -440,6 +467,10 @@ let
               {
                 file = "/etc/wpa_supplicant.conf";
                 how = "symlink";
+              }
+              {
+                file = "/etc/localtime";
+                how = "copy";
               }
               {
                 file = "/etc/machine-id";

--- a/options.nix
+++ b/options.nix
@@ -37,7 +37,14 @@ let
           ];
           default = "bindmount";
           description = ''
-            Specify how this directory should be preserved.
+            Specify how this directory should be preserved:
+
+            1. Either a directory is placed both on the volatile and on
+            the persistent volume, with a bind mount from the former to
+            the latter.
+
+            2. Or a symlink is created on the volatile volume, pointing
+            to the corresponding location on the persistent volume.
           '';
         };
         user = lib.mkOption {

--- a/tests/basic.nix
+++ b/tests/basic.nix
@@ -27,6 +27,7 @@ in
           ];
           files = [
             { file = "/etc/wpa_supplicant.conf"; how = "symlink"; }
+            { file = "/etc/localtime"; how = "copy"; }
             # some files need to be prepared very early, machine-id is one such case
             { file = "/etc/machine-id"; inInitrd = true; }
           ];
@@ -133,6 +134,14 @@ in
             machine.succeed(f"mountpoint {path}")
 
             # check permissions and ownership
+            actual = machine.succeed(f"stat -c '0%a %U %G' {path} | tee /dev/stderr").strip()
+            expected = "{} {} {}".format(config["mode"],config["user"],config["group"])
+            assert actual == expected,f"unexpected file attributes\nexpected: {expected}\nactual: {actual}"
+
+          case "copy":
+            # check that file exists
+            machine.succeed(f"test -e {path}")
+
             actual = machine.succeed(f"stat -c '0%a %U %G' {path} | tee /dev/stderr").strip()
             expected = "{} {} {}".format(config["mode"],config["user"],config["group"])
             assert actual == expected,f"unexpected file attributes\nexpected: {expected}\nactual: {actual}"


### PR DESCRIPTION
This PR adds a `how = "copy"` synchronization method that persists files by copying them from the persistent storage to the root and back.

The problem that motivates this PR is that, currently, the two available methods (bind-mounts and symlinks) are not capable of persisting symlinks like `/etc/timezone -> ../etc/zoneinfo/<your_region>`. The reason for their failure is that both methods follow the symlink, yet its destination does not exist on the persistent storage.

To bridge this gap, this PR adds the _copy_ method: It copies files and directories from the persistent storage to the root on startup and copies them back from the root to the persistent storage on shutdown. The weakness of this method is that it is not resilient against system crashes since in that case, the reverse copy operation is not triggered.